### PR TITLE
Crash fix: Don't minimize shadowed dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1673027205
+//version: 1674294951
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -144,6 +144,7 @@ propertyDefaultIfUnset("modrinthProjectId", "")
 propertyDefaultIfUnset("modrinthRelations", "")
 propertyDefaultIfUnset("curseForgeProjectId", "")
 propertyDefaultIfUnset("curseForgeRelations", "")
+propertyDefaultIfUnset("minimizeShadowedDependencies", true)
 
 String javaSourceDir = "src/main/java/"
 String scalaSourceDir = "src/main/scala/"
@@ -411,7 +412,9 @@ shadowJar {
         attributes(getManifestAttributes())
     }
 
-    minimize()  // This will only allow shading for actually used classes
+    if (minimizeShadowedDependencies.toBoolean()) {
+        minimize()  // This will only allow shading for actually used classes
+    }
     configurations = [
         project.configurations.shadowImplementation,
         project.configurations.shadowCompile
@@ -554,7 +557,9 @@ task shadowDevJar(type: ShadowJar) {
         attributes(getManifestAttributes())
     }
 
-    minimize()  // This will only allow shading for actually used classes
+    if (minimizeShadowedDependencies.toBoolean()) {
+        minimize()  // This will only allow shading for actually used classes
+    }
     configurations = [
         project.configurations.shadowImplementation,
         project.configurations.shadowCompile

--- a/gradle.properties
+++ b/gradle.properties
@@ -58,6 +58,9 @@ containsMixinsAndOrCoreModOnly = false
 # If enabled, you may use 'shadowImplementation' for dependencies. They will be integrated in your jar. It is your
 # responsibility check the licence and request permission for distribution, if required.
 usesShadowedDependencies = true
+# If disabled, won't remove unused classes from shaded dependencies. Some libraries use reflection to access
+# their own classes, making the minimization unreliable.
+minimizeShadowedDependencies = false
 
 # Optional parameter to customize the produced artifacts. Use this to preserver artifact naming when migrating older
 # projects. New projects should not use this parameter.

--- a/src/main/java/eu/usrv/enhancedlootbags/core/LootGroupsHandler.java
+++ b/src/main/java/eu/usrv/enhancedlootbags/core/LootGroupsHandler.java
@@ -32,6 +32,7 @@ import eu.usrv.yamcore.auxiliary.LogHelper;
 import eu.usrv.yamcore.auxiliary.TextFormatHelper;
 import eu.usrv.yamcore.persisteddata.PersistedDataBase;
 import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
 import jakarta.xml.bind.Unmarshaller;
 import java.io.File;
@@ -273,10 +274,16 @@ public class LootGroupsHandler {
      * @return
      */
     public boolean SaveLootGroups() {
+        final Marshaller jaxMarsh;
         try {
-            JAXBContext tJaxbCtx = JAXBContext.newInstance(LootGroups.class);
-            Marshaller jaxMarsh = tJaxbCtx.createMarshaller();
+            final JAXBContext tJaxbCtx = JAXBContext.newInstance(LootGroups.class);
+            jaxMarsh = tJaxbCtx.createMarshaller();
             jaxMarsh.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+        } catch (JAXBException e) {
+            _mLogger.error("[LootBags] Unable to construct JAXB context. " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+        try {
             jaxMarsh.marshal(_mLootGroups, new FileOutputStream(_mConfigFileName, false));
 
             // _mLogger.debug("[LootBags] Config file written");
@@ -469,10 +476,15 @@ public class LootGroupsHandler {
         boolean tResult = false;
 
         // _mLogger.debug("[LootBags] LootGroupsHandler will now try to load its configuration");
+        final Unmarshaller jaxUnmarsh;
         try {
-            JAXBContext tJaxbCtx = JAXBContext.newInstance(LootGroups.class);
-            Unmarshaller jaxUnmarsh = tJaxbCtx.createUnmarshaller();
-
+            final JAXBContext tJaxbCtx = JAXBContext.newInstance(LootGroups.class);
+            jaxUnmarsh = tJaxbCtx.createUnmarshaller();
+        } catch (JAXBException e) {
+            _mLogger.error("[LootBags] Unable to construct JAXB context. " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+        try {
             LootGroups tNewItemCollection = null;
             boolean tLocalConfig = pXMLContent.isEmpty();
 


### PR DESCRIPTION
Requires <https://github.com/GTNewHorizons/ExampleMod1.7.10/pull/110>.
JAXB uses reflection to access its own classes, which makes shadowjar minimization not see their usage properly so they got removed.