### PR TITLE
Customizable Lootbag icons

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ channel = stable
 mappingsVersion = 12
 
 # Defines other MCP mappings for dependency deobfuscation.
-remoteMappings = https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
+remoteMappings = https\://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
 
 # Select a default username for testing your mod. You can always override this per-run by running
 # `./gradlew runClient --username=AnotherPlayer`, or configuring this command in your IDE.
@@ -61,6 +61,9 @@ gradleTokenModId =
 # [DEPRECATED] Mod name replacement token.
 gradleTokenModName =
 
+# [DEPRECATED] Mod Group replacement token.
+gradleTokenGroupName =
+
 # [DEPRECATED]
 # Multiple source files can be defined here by providing a comma-separated list: Class1.java,Class2.java,Class3.java
 # public static final String VERSION = "GRADLETOKEN_VERSION";
@@ -81,6 +84,11 @@ accessTransformersFile =
 
 # Provides setup for Mixins if enabled. If you don't know what mixins are: Keep it disabled!
 usesMixins = false
+
+# Set to a non-empty string to configure mixins in a separate source set under src/VALUE, instead of src/main.
+# This can speed up compile times thanks to not running the mixin annotation processor on all input sources.
+# Mixin classes will have access to "main" classes, but not the other way around.
+separateMixinSourceSet =
 
 # Adds some debug arguments like verbose output and class export.
 usesMixinDebug = false
@@ -114,8 +122,14 @@ minimizeShadowedDependencies = true
 # If disabled, won't rename the shadowed classes.
 relocateShadowedDependencies = true
 
-# Adds the GTNH maven, CurseMaven, IC2/Player maven, and some more well-known 1.7.10 repositories.
+# Adds CurseMaven, Modrinth, and some more well-known 1.7.10 repositories.
 includeWellKnownRepositories = true
+
+# A list of repositories to exclude from the includeWellKnownRepositories setting. Should be a space separated
+# list of strings, with the acceptable keys being(case does not matter):
+# cursemaven
+# modrinth
+excludeWellKnownRepositories =
 
 # Change these to your Maven coordinates if you want to publish to a custom Maven repository instead of the default GTNH Maven.
 # Authenticate with the MAVEN_USER and MAVEN_PASSWORD environment variables.
@@ -123,7 +137,7 @@ includeWellKnownRepositories = true
 usesMavenPublishing = true
 
 # Maven repository to publish the mod to.
-# mavenPublishUrl = https://nexus.gtnewhorizons.com/repository/releases/
+# mavenPublishUrl = https\://nexus.gtnewhorizons.com/repository/releases/
 
 # Publishing to Modrinth requires you to set the MODRINTH_TOKEN environment variable to your current Modrinth API token.
 #
@@ -187,5 +201,3 @@ disableCheckstyle = true
 # This is meant to be set in $HOME/.gradle/gradle.properties.
 # ideaCheckSpotlessOnBuild = true
 
-# Non-GTNH properties
-gradleTokenGroupName = 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.8'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.30'
 }
 
 

--- a/src/main/java/eu/usrv/enhancedlootbags/core/items/ItemLootBag.java
+++ b/src/main/java/eu/usrv/enhancedlootbags/core/items/ItemLootBag.java
@@ -69,6 +69,7 @@ public class ItemLootBag extends Item {
     @SideOnly(Side.CLIENT)
     public void registerIcons(IIconRegister pIconRegister) {
         _mIcoDefault = pIconRegister.registerIcon(String.format("%s:lootbag_generic", EnhancedLootBags.MODID));
+        _mGroupIcons.clear();
         for (LootGroup tGrp : _mLGHandler.getLootGroups().getLootTable()) {
             tGrp.getGroupIconResource()
                     .ifPresent(icon -> _mGroupIcons.put(tGrp.getGroupID(), pIconRegister.registerIcon(icon)));

--- a/src/main/java/eu/usrv/enhancedlootbags/core/items/ItemLootBag.java
+++ b/src/main/java/eu/usrv/enhancedlootbags/core/items/ItemLootBag.java
@@ -10,7 +10,9 @@
 package eu.usrv.enhancedlootbags.core.items;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
@@ -39,6 +41,7 @@ import eu.usrv.yamcore.auxiliary.PlayerChatHelper;
 public class ItemLootBag extends Item {
 
     private IIcon _mIcoDefault;
+    private final Map<Integer, IIcon> _mGroupIcons = new HashMap<>();
     private final LootGroupsHandler _mLGHandler;
     private LogHelper _mLogger = EnhancedLootBags.Logger;
 
@@ -66,16 +69,15 @@ public class ItemLootBag extends Item {
     @SideOnly(Side.CLIENT)
     public void registerIcons(IIconRegister pIconRegister) {
         _mIcoDefault = pIconRegister.registerIcon(String.format("%s:lootbag_generic", EnhancedLootBags.MODID));
-        // for (LootGroup tGrp : _mLGHandler.getLootGroups().getLootTable())
-        // tGrp.setGroupIcon(pIconRegister.registerIcon(String.format("%s:lootbags/lootbag_%d",
-        // Refstrings.MODID, tGrp.mGroupID)));
+        for (LootGroup tGrp : _mLGHandler.getLootGroups().getLootTable()) {
+            tGrp.getGroupIconResource()
+                    .ifPresent(icon -> _mGroupIcons.put(tGrp.getGroupID(), pIconRegister.registerIcon(icon)));
+        }
     }
 
     @SideOnly(Side.CLIENT)
-    public IIcon getIconFromDamage(int par1) {
-        // LootGroup tGrp = getGroupByID(par1);
-        // return tGrp == null ? _mIcoDefault : tGrp.getGroupIcon();
-        return _mIcoDefault;
+    public IIcon getIconFromDamage(int meta) {
+        return _mGroupIcons.getOrDefault(meta, _mIcoDefault);
     }
 
     @Override

--- a/src/main/java/eu/usrv/enhancedlootbags/core/serializer/LootGroups.java
+++ b/src/main/java/eu/usrv/enhancedlootbags/core/serializer/LootGroups.java
@@ -12,6 +12,7 @@ package eu.usrv.enhancedlootbags.core.serializer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlAccessType;
@@ -24,7 +25,6 @@ import javax.xml.bind.annotation.XmlType;
 
 import net.minecraft.item.EnumRarity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.IIcon;
 
 import eu.usrv.enhancedlootbags.EnhancedLootBags;
 import eu.usrv.enhancedlootbags.core.LootGroupsHandler;
@@ -88,8 +88,12 @@ public class LootGroups {
             return mMaxWeight;
         }
 
-        @XmlTransient
-        private IIcon mGroupIcon;
+        @XmlAttribute(name = "LootbagIcon")
+        private String mGroupIconResource;
+
+        public Optional<String> getGroupIconResource() {
+            return Optional.ofNullable(mGroupIconResource);
+        }
 
         @XmlElement(name = "Loot")
         private List<LootGroups.LootGroup.Drop> mDrops;
@@ -118,14 +122,6 @@ public class LootGroups {
         public EnumRarity getGroupRarity() {
             if (mRarity >= 0 && mRarity < EnumRarity.values().length) return EnumRarity.values()[mRarity];
             else return EnumRarity.common;
-        }
-
-        public IIcon getGroupIcon() {
-            return mGroupIcon;
-        }
-
-        public void setGroupIcon(IIcon pIcon) {
-            mGroupIcon = pIcon;
         }
 
         public ItemStack createLootBagItemStack() {


### PR DESCRIPTION
It turns out this was a planned feature that never got finished. Replaced vestigial code with functioning feature to allow specifying custom item icons per lootbag.

## More work required

This is all of the required code changes for this feature, but it won't change anything in the pack. New icons need to be added in https://github.com/GTNewHorizons/NewHorizonsCoreMod and those need to be referenced in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/blob/master/config/EnhancedLootBags/LootBags.xml.

## Sample usage

1. Add the desired lootbag icon to some other mod (like the GTNH core mod) under `%MODID%/textures/items/`.

2. Reference the icon by combined mod Id and item texture name using the `LootbagIcon` property of `LootGroup` tags in `LootBags.xml`.
```xml
<LootGroup GroupMetaID="11" GroupName="Magic Master" Rarity="2" MinItems="1" MaxItems="2" CombineTrashGroup="true" LootbagIcon="dreamcraft:itemLootbagRare">
    ...
</LootGroup>
```


## Proof of concept test icons (Not included)

<img src="https://github.com/user-attachments/assets/21cfe74e-ff44-4cf3-b186-66f6d85ff9b6" width="400">
<br>
<img src="https://github.com/user-attachments/assets/0b01f28c-8cde-4f4b-8961-3291e0eb997e" width="200">
<img src="https://github.com/user-attachments/assets/12b7808f-c5bb-414c-91fa-3cd50d049a7a" width="200">
<img src="https://github.com/user-attachments/assets/a283c347-aa8e-45ce-b92a-37923d52981b" width="200">
<br>
<img src="https://github.com/user-attachments/assets/66252ac1-af0e-45d5-9171-391db3881339" width="200">
<img src="https://github.com/user-attachments/assets/b61fcf9e-9ac5-4f63-aaa4-b9cce22f9074" width="400">
<br>

