### PR TITLE
Better communicate the purpose of enchanting lootbags

### DIFF
--- a/src/main/java/eu/usrv/enhancedlootbags/core/items/ItemLootBag.java
+++ b/src/main/java/eu/usrv/enhancedlootbags/core/items/ItemLootBag.java
@@ -101,7 +101,7 @@ public class ItemLootBag extends Item {
             ItemStack s1 = new ItemStack(this, 1, tGrp.getGroupID());
             par3List.add(s1);
 
-            if (EnhancedLootBags.ELBCfg.AllowFortuneBags) {
+            if (EnhancedLootBags.ELBCfg.AllowFortuneBags && tGrp.getCombineWithTrash()) {
                 ItemStack s2 = s1.copy();
                 s2.addEnchantment(Enchantment.fortune, 3);
                 par3List.add(s2);

--- a/src/main/java/eu/usrv/enhancedlootbags/core/items/ItemLootBag.java
+++ b/src/main/java/eu/usrv/enhancedlootbags/core/items/ItemLootBag.java
@@ -267,7 +267,9 @@ public class ItemLootBag extends Item {
     @SideOnly(Side.CLIENT)
     public void addInformation(ItemStack pItemStack, EntityPlayer pEntityPlayer, List pTooltipList,
             boolean pSomeBooleanValue) {
-        if (EnhancedLootBags.ELBCfg.AllowFortuneBags) {
+        if (!_mLGHandler.getGroupByID(pItemStack.getItemDamage()).getCombineWithTrash()) {
+            pTooltipList.add(StatHelper.get("string.no_fortune_needed"));
+        } else if (EnhancedLootBags.ELBCfg.AllowFortuneBags) {
             int tFortuneLevel = EnchantmentHelper.getEnchantmentLevel(Enchantment.fortune.effectId, pItemStack);
             if (tFortuneLevel == 0) pTooltipList.add(StatHelper.get("string.not_fortuned"));
             else pTooltipList.add(

--- a/src/main/resources/assets/enhancedlootbags/lang/en_US.lang
+++ b/src/main/resources/assets/enhancedlootbags/lang/en_US.lang
@@ -3,7 +3,7 @@ enhancedlootbags.string.default=Default
 enhancedlootbags.string.try_again=That didn't work. Please try again!
 enhancedlootbags.string.sorry_damaged=This LootBag seems to be damaged, sorry about that
 enhancedlootbags.string.not_fortuned=§5You feel that a bit more "Fortune" might be a good idea...
-enhancedlootbags.string.fortuned=§6Your luck is increased by %d %%
+enhancedlootbags.string.fortuned=§6Contains %d %% fewer surprises.
 itemGroup.ELBTab=Enhanced LootBags
 
 enhancedlootbags.nei.category=LootBag

--- a/src/main/resources/assets/enhancedlootbags/lang/en_US.lang
+++ b/src/main/resources/assets/enhancedlootbags/lang/en_US.lang
@@ -3,6 +3,7 @@ enhancedlootbags.string.default=Default
 enhancedlootbags.string.try_again=That didn't work. Please try again!
 enhancedlootbags.string.sorry_damaged=This LootBag seems to be damaged, sorry about that
 enhancedlootbags.string.not_fortuned=§5You feel that a bit more "Fortune" might be a good idea...
+enhancedlootbags.string.no_fortune_needed=You're feeling lucky!
 enhancedlootbags.string.fortuned=§6Contains %d %% fewer surprises.
 itemGroup.ELBTab=Enhanced LootBags
 

--- a/src/main/resources/assets/enhancedlootbags/lang/en_US.lang
+++ b/src/main/resources/assets/enhancedlootbags/lang/en_US.lang
@@ -4,7 +4,7 @@ enhancedlootbags.string.try_again=That didn't work. Please try again!
 enhancedlootbags.string.sorry_damaged=This LootBag seems to be damaged, sorry about that
 enhancedlootbags.string.not_fortuned=§5You feel that a bit more "Fortune" might be a good idea...
 enhancedlootbags.string.no_fortune_needed=You're feeling lucky!
-enhancedlootbags.string.fortuned=§6Contains %d %% fewer surprises.
+enhancedlootbags.string.fortuned=§6Contains %d %% fewer low-tier drops.
 itemGroup.ELBTab=Enhanced LootBags
 
 enhancedlootbags.nei.category=LootBag


### PR DESCRIPTION
### Lootbags which don't benefit from enchantments don't have an enchanted variation added to NEI.
![image](https://github.com/user-attachments/assets/277ba322-f83b-499e-a7f2-e1ee5b4729ba)

### The enchanted lootbag tooltip better describes it's effect of giving you less junk, not more stuff.
![image](https://github.com/user-attachments/assets/70e07d82-f2b5-404f-af59-23af5244a915)

### Add a tooltip to lootbags that don't need enchanting to signal you can just open them right now.
![image](https://github.com/user-attachments/assets/36277e51-37c7-412e-95ae-4aee92a86835)


